### PR TITLE
feat: make Docker entrypoint idempotent — auto-update agents and CLI commands on boot

### DIFF
--- a/agents/forge/.protected
+++ b/agents/forge/.protected
@@ -1,0 +1,6 @@
+# Files that belong to the user after first install.
+# Patterns are matched against filenames using bash glob syntax.
+# One pattern per line. Blank lines and #-comments are ignored.
+config.json
+USER.md
+*.db

--- a/agents/scouter/.protected
+++ b/agents/scouter/.protected
@@ -1,0 +1,6 @@
+# Files that belong to the user after first install.
+# Patterns are matched against filenames using bash glob syntax.
+# One pattern per line. Blank lines and #-comments are ignored.
+config.json
+USER.md
+*.db

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # this shell's environment and should use `return` (not `exit`) to bail out.
 
 INIT_DIR="/usr/local/lib/openclaw-init.d"
-MARKER="$HOME/.openclaw/workspace/.initialized"
 
 # Shared helpers for init scripts (sourced into same shell)
 log() { echo "[init] $SCRIPT_NAME: $*"; }
@@ -13,10 +12,8 @@ log() { echo "[init] $SCRIPT_NAME: $*"; }
 # Agents with Discord integration (used by 03-channels.sh and 05-bindings.sh)
 DISCORD_AGENTS="forge scouter"
 
-if [ -f "$MARKER" ]; then
-    echo "[init] Already initialized. Starting gateway..."
-    exec "$@"
-fi
+# Clean up legacy first-boot marker (no longer used)
+rm -f "$HOME/.openclaw/workspace/.initialized"
 
 # Pre-seed minimal config so the gateway can start with non-loopback bind
 CONFIG_FILE="$HOME/.openclaw/openclaw.json"
@@ -30,8 +27,8 @@ if [ ! -f "$CONFIG_FILE" ] || ! jq -e '.gateway.controlUi.allowedOrigins' "$CONF
     echo "[init] Pre-seeded controlUi.allowedOrigins in config."
 fi
 
-# First boot: start gateway in background so CLI commands can talk to it
-echo "[init] First boot detected. Starting gateway for configuration..."
+# Start gateway in background so CLI commands can talk to it
+echo "[init] Starting gateway for configuration..."
 "$@" &
 GATEWAY_PID=$!
 
@@ -64,9 +61,7 @@ done
 # Apply any config migrations flagged by the CLI
 node dist/index.js doctor --fix 2>/dev/null || true
 
-mkdir -p "$(dirname "$MARKER")"
-touch "$MARKER"
-echo "[init] Setup complete. Gateway is running."
+echo "[init] Init complete. Gateway is running."
 
 # Keep container alive by waiting on the gateway process
 wait "$GATEWAY_PID"

--- a/init.d/04-agents.sh
+++ b/init.d/04-agents.sh
@@ -5,19 +5,6 @@
 AGENT_TEMPLATES="/opt/openclaw-agents"
 WORKSPACE="$HOME/.openclaw/workspace"
 
-# is_protected <filename> <protected_file>
-# Returns 0 if filename matches any pattern in the .protected file.
-is_protected() {
-    local filename="$1" protected_file="$2"
-    [ -f "$protected_file" ] || return 1
-    while IFS= read -r pattern || [ -n "$pattern" ]; do
-        [[ "$pattern" =~ ^[[:space:]]*$ || "$pattern" =~ ^# ]] && continue
-        # shellcheck disable=SC2254
-        [[ "$filename" == $pattern ]] && return 0
-    done < "$protected_file"
-    return 1
-}
-
 for agent_dir in "$AGENT_TEMPLATES"/*/; do
     [ -d "$agent_dir" ] || continue
     agent_name=$(basename "$agent_dir")
@@ -68,14 +55,26 @@ for agent_dir in "$AGENT_TEMPLATES"/*/; do
     else
         # --- Existing agent: sync definition files ---
         log "Syncing agent '$agent_name'..."
-        protected_file="$agent_dir/.protected"
+
+        # Cache protected patterns (read .protected file once, not per-file)
+        protected_patterns=()
+        if [ -f "$agent_dir/.protected" ]; then
+            while IFS= read -r pattern || [ -n "$pattern" ]; do
+                [[ "$pattern" =~ ^[[:space:]]*$ || "$pattern" =~ ^# ]] && continue
+                protected_patterns+=("$pattern")
+            done < "$agent_dir/.protected"
+        fi
 
         for src_file in "$agent_dir"*; do
             [ -e "$src_file" ] || continue
             filename=$(basename "$src_file")
-            [ "$filename" = ".protected" ] && continue
 
-            if is_protected "$filename" "$protected_file"; then
+            skip=false
+            for pattern in "${protected_patterns[@]}"; do
+                # shellcheck disable=SC2254
+                [[ "$filename" == $pattern ]] && skip=true && break
+            done
+            if [ "$skip" = true ]; then
                 log "  Protected: $filename"
                 continue
             fi

--- a/init.d/04-agents.sh
+++ b/init.d/04-agents.sh
@@ -1,69 +1,94 @@
 #!/usr/bin/env bash
-# 04-agents.sh — Install agents and initialize databases
+# 04-agents.sh — Install new agents or sync definition files for existing ones
 # SCRIPT_NAME and log() are provided by docker-entrypoint.sh
 
 AGENT_TEMPLATES="/opt/openclaw-agents"
 WORKSPACE="$HOME/.openclaw/workspace"
 
+# is_protected <filename> <protected_file>
+# Returns 0 if filename matches any pattern in the .protected file.
+is_protected() {
+    local filename="$1" protected_file="$2"
+    [ -f "$protected_file" ] || return 1
+    while IFS= read -r pattern || [ -n "$pattern" ]; do
+        [[ "$pattern" =~ ^[[:space:]]*$ || "$pattern" =~ ^# ]] && continue
+        # shellcheck disable=SC2254
+        [[ "$filename" == $pattern ]] && return 0
+    done < "$protected_file"
+    return 1
+}
+
 for agent_dir in "$AGENT_TEMPLATES"/*/; do
     [ -d "$agent_dir" ] || continue
     agent_name=$(basename "$agent_dir")
     target="$WORKSPACE/agents/$agent_name"
-    sentinel="$target/SOUL.md"
 
-    # Check sentinel file for complete installation
-    if [ -f "$sentinel" ]; then
-        log "Agent '$agent_name' already installed, skipping."
-        continue
-    fi
+    if [ ! -d "$target" ]; then
+        # --- New agent: full install ---
+        log "Installing agent '$agent_name'..."
 
-    log "Installing agent '$agent_name'..."
-
-    # Register agent with OpenClaw (may fail if already partially registered)
-    if ! node dist/index.js agents add "$agent_name" --workspace "$target" --non-interactive 2>/dev/null; then
-        log "WARNING: 'agents add' failed for $agent_name (may already be registered). Continuing with file copy."
-    fi
-
-    # Copy agent files from template
-    mkdir -p "$target"
-    cp -r "$agent_dir"* "$target/"
-
-    # Rename .example.* files to their real names
-    for example in "$target"/*.example.*; do
-        [ -f "$example" ] || continue
-        real="${example/.example/}"
-        mv "$example" "$real"
-    done
-
-    # Clear projects list (user adds repos via Discord)
-    if [ -f "$target/config.json" ]; then
-        jq '.projects = []' "$target/config.json" > "$target/config.json.tmp" \
-            && mv "$target/config.json.tmp" "$target/config.json"
-    fi
-
-    # Configure heartbeat target if agent has a Discord channel
-    UPPER=$(echo "$agent_name" | tr '[:lower:]' '[:upper:]')
-    CHANNEL_VAR="DISCORD_${UPPER}_CHANNEL"
-    CHANNEL="${!CHANNEL_VAR:-}"
-    if [ -n "$CHANNEL" ]; then
-        # Find the agent's index in agents.list
-        AGENT_INDEX=$(node dist/index.js config get agents.list 2>/dev/null \
-            | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));console.log(d.findIndex(a=>a.id==='$agent_name'))" 2>/dev/null)
-        if [ -n "$AGENT_INDEX" ] && [ "$AGENT_INDEX" != "-1" ]; then
-            log "Configuring heartbeat target for $agent_name (index: $AGENT_INDEX, channel: $CHANNEL)..."
-            node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.every" '"0m"' --json
-            node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.target" '"discord"' --json
-            node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.to" "\"channel:$CHANNEL\"" --json
-        else
-            log "WARNING: could not find agent index for $agent_name, skipping heartbeat config"
+        if ! node dist/index.js agents add "$agent_name" --workspace "$target" --non-interactive 2>/dev/null; then
+            log "WARNING: 'agents add' failed for $agent_name (may already be registered). Continuing."
         fi
-    fi
 
-    log "OK"
+        mkdir -p "$target"
+        cp -r "$agent_dir"* "$target/"
+
+        # Rename .example.* files to their real names
+        for example in "$target"/*.example.*; do
+            [ -f "$example" ] || continue
+            real="${example/.example/}"
+            mv "$example" "$real"
+        done
+
+        # Clear projects list (user adds repos via Discord)
+        if [ -f "$target/config.json" ]; then
+            jq '.projects = []' "$target/config.json" > "$target/config.json.tmp" \
+                && mv "$target/config.json.tmp" "$target/config.json"
+        fi
+
+        # Configure heartbeat target if agent has a Discord channel
+        UPPER=$(echo "$agent_name" | tr '[:lower:]' '[:upper:]')
+        CHANNEL_VAR="DISCORD_${UPPER}_CHANNEL"
+        CHANNEL="${!CHANNEL_VAR:-}"
+        if [ -n "$CHANNEL" ]; then
+            AGENT_INDEX=$(node dist/index.js config get agents.list 2>/dev/null \
+                | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));console.log(d.findIndex(a=>a.id==='$agent_name'))" 2>/dev/null)
+            if [ -n "$AGENT_INDEX" ] && [ "$AGENT_INDEX" != "-1" ]; then
+                log "Configuring heartbeat for $agent_name (index: $AGENT_INDEX, channel: $CHANNEL)..."
+                node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.every" '"0m"' --json
+                node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.target" '"discord"' --json
+                node dist/index.js config set "agents.list[$AGENT_INDEX].heartbeat.to" "\"channel:$CHANNEL\"" --json
+            else
+                log "WARNING: could not find agent index for $agent_name, skipping heartbeat config"
+            fi
+        fi
+
+        log "Installed $agent_name."
+    else
+        # --- Existing agent: sync definition files ---
+        log "Syncing agent '$agent_name'..."
+        protected_file="$agent_dir/.protected"
+
+        for src_file in "$agent_dir"*; do
+            [ -e "$src_file" ] || continue
+            filename=$(basename "$src_file")
+            [ "$filename" = ".protected" ] && continue
+
+            if is_protected "$filename" "$protected_file"; then
+                log "  Protected: $filename"
+                continue
+            fi
+
+            cp "$src_file" "$target/$filename"
+            log "  Synced: $filename"
+        done
+
+        log "Synced $agent_name."
+    fi
 done
 
-# Initialize agent databases (runs for all agents, not just newly installed ones).
-# The *-db.sh init commands are idempotent (CREATE TABLE IF NOT EXISTS).
+# Initialize agent databases (idempotent: CREATE TABLE IF NOT EXISTS)
 for db_script in "$WORKSPACE"/agents/*/*-db.sh; do
     [ -f "$db_script" ] || continue
     agent_name=$(basename "$(dirname "$db_script")")

--- a/init.d/07-claude.sh
+++ b/init.d/07-claude.sh
@@ -1,36 +1,38 @@
 #!/usr/bin/env bash
-# 07-claude.sh — Claude CLI settings and plugins
+# 07-claude.sh — Claude CLI settings, commands, and plugins
 # SCRIPT_NAME and log() are provided by docker-entrypoint.sh
 # Auth is handled by CLAUDE_CODE_OAUTH_TOKEN env var (no setup needed).
 
 CLAUDE_DIR="$HOME/.claude"
 SETTINGS="$CLAUDE_DIR/settings.json"
 
-if [ -f "$SETTINGS" ]; then
-    log "Claude CLI settings already exist, skipping."
-    return 0
-fi
-
-log "Creating Claude CLI settings..."
-mkdir -p "$CLAUDE_DIR"
-cat > "$SETTINGS" <<'JSON'
+# --- Settings (user data, create only if missing) ---
+if [ ! -f "$SETTINGS" ]; then
+    log "Creating Claude CLI settings..."
+    mkdir -p "$CLAUDE_DIR"
+    cat > "$SETTINGS" <<'JSON'
 {"plugins":{"allow":["acpx"]}}
 JSON
+fi
 
-# Copy bundled commands
+# --- Bundled commands (always sync from image) ---
 COMMANDS_SRC="/opt/claude/commands"
 COMMANDS_DST="$CLAUDE_DIR/commands"
 if [ -d "$COMMANDS_SRC" ]; then
     mkdir -p "$COMMANDS_DST"
     cp -r "$COMMANDS_SRC"/* "$COMMANDS_DST/"
-    log "Installed bundled commands: $(ls "$COMMANDS_DST" | tr '\n' ' ')"
+    log "Synced bundled commands: $(ls "$COMMANDS_DST" | tr '\n' ' ')"
 fi
 
-# Add official marketplace and install plugins
-log "Adding official plugin marketplace..."
-claude plugin marketplace add anthropics/claude-plugins-official
+# --- Plugins (install only if not already set up) ---
+if [ ! -d "$CLAUDE_DIR/plugins" ]; then
+    log "Adding official plugin marketplace..."
+    claude plugin marketplace add anthropics/claude-plugins-official
 
-log "Installing superpowers plugin..."
-claude plugin install superpowers
+    log "Installing superpowers plugin..."
+    claude plugin install superpowers
+else
+    log "Claude plugins already installed."
+fi
 
 log "OK"


### PR DESCRIPTION
## Summary
- Remove the global `.initialized` marker so all init scripts run on every container boot, enabling automatic agent template and CLI command updates when the image is rebuilt
- Rewrite `04-agents.sh` to sync definition files for existing agents while respecting `.protected` exclusion lists that preserve user data (config.json, USER.md, *.db)
- Rewrite `07-claude.sh` to always sync bundled commands from the image while preserving user settings and installed plugins

## Completed Tasks
- [x] Remove `.initialized` marker from docker-entrypoint.sh, always run init scripts
- [x] Add `agents/forge/.protected` and `agents/scouter/.protected` with user data patterns
- [x] Rewrite `init.d/04-agents.sh` with install-or-sync logic respecting `.protected`
- [x] Rewrite `init.d/07-claude.sh` to sync commands on every boot, guard settings and plugins
- [x] Cache `.protected` patterns to avoid repeated file reads during sync

Closes #15

---
Generated by `/build` from GitHub issue #15