### PR TITLE
chore: enable gateway auth rate limiting

### DIFF
--- a/init.d/01-gateway.sh
+++ b/init.d/01-gateway.sh
@@ -8,6 +8,10 @@ node dist/index.js config set gateway.mode local
 # Disable memory search (no embedding provider configured)
 node dist/index.js config set agents.defaults.memorySearch.enabled false
 
+# Rate-limit auth attempts to prevent brute-force attacks
+node dist/index.js config set gateway.auth.rateLimit \
+  '{"maxAttempts":10,"windowMs":60000,"lockoutMs":300000,"exemptLoopback":true}' --json
+
 # Check if gateway token is already configured
 if node dist/index.js config get gateway.auth.token 2>/dev/null | grep -q .; then
     log "Gateway token already configured, skipping."

--- a/init.d/01-gateway.sh
+++ b/init.d/01-gateway.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # 01-gateway.sh — Gateway token configuration
 # SCRIPT_NAME and log() are provided by docker-entrypoint.sh
+#
+# Structure: unconditional defaults run first on every boot, then token
+# initialisation (guarded — runs once). Add new always-enforce config above
+# the token guard; add one-time setup below it.
 
 # Set gateway mode (required by doctor)
 node dist/index.js config set gateway.mode local


### PR DESCRIPTION
## Summary
- Adds `gateway.auth.rateLimit` config to `init.d/01-gateway.sh` so the gateway enforces brute-force throttling on every container boot
- Defaults: 10 failed attempts per 60s window → 5-minute lockout; loopback connections exempt
- Placed before the token-guard early-return so it runs unconditionally, consistent with other always-enforce config (gateway.mode, memorySearch.enabled)

## Completed Tasks
- Added rate-limit `config set` call to `init.d/01-gateway.sh` before the early-return token guard
- Added structural comment documenting the two-section pattern (unconditional defaults vs one-time token init)

---
Generated by `/build` from GitHub issue #8