### PR TITLE
chore: configure session maintenance policy

### DIFF
--- a/init.d/01-gateway.sh
+++ b/init.d/01-gateway.sh
@@ -8,6 +8,10 @@ node dist/index.js config set gateway.mode local
 # Disable memory search (no embedding provider configured)
 node dist/index.js config set agents.defaults.memorySearch.enabled false
 
+# Cap session store growth (enforce prune vs warn-only)
+node dist/index.js config set session.maintenance \
+  '{"mode":"enforce","pruneAfter":"14d","maxEntries":200,"rotateBytes":"10mb"}' --json
+
 # Check if gateway token is already configured
 if node dist/index.js config get gateway.auth.token 2>/dev/null | grep -q .; then
     log "Gateway token already configured, skipping."


### PR DESCRIPTION
## Summary
- Adds `session.maintenance` config to `init.d/01-gateway.sh` so sessions are pruned automatically instead of accumulating indefinitely in `sessions.json`
- Configured with `mode: enforce` (prune automatically), 14-day retention, 200-entry cap, and 10mb rotation threshold

## Completed Tasks
- Modified `init.d/01-gateway.sh` to add `config set session.maintenance` in the unconditional config block (runs on every container start alongside `gateway.mode` and `memorySearch.enabled`)

---
Generated by `/build` from GitHub issue #11