### PR TITLE
feat: GitHub webhooks integration for Forge

### DIFF
--- a/agents/forge/AGENTS.md
+++ b/agents/forge/AGENTS.md
@@ -2,6 +2,26 @@
 
 ## Two modes of operation
 
+### Webhook flow (real-time)
+
+When GitHub webhooks are configured, Forge is triggered immediately on `issues.opened`:
+
+```
+GitHub (issues.opened event)
+  → POST https://<tailscale-hostname>/hooks/github       (Tailscale Funnel, /hooks/ only)
+    → HMAC proxy (validates X-Hub-Signature-256, adds Bearer token, port 18791)
+      → OpenClaw gateway :18789/hooks/github
+        → messageTemplate: "run <owner/repo> #<number>"
+          → Forge applies selection filters → spawns ACP session if eligible
+```
+
+The HMAC proxy (`scripts/gh-webhook-proxy.py`) runs as a systemd service on the host. See `docs/webhooks-setup.md` for setup.
+
+The 2h heartbeat remains active as a fallback for:
+- Issues created while the NAS was offline
+- GitHub webhook delivery failures
+- Issues that exceeded concurrency limits when first triggered
+
 ### 1. Cron cycle (heartbeat)
 
 On each heartbeat tick:
@@ -15,17 +35,18 @@ On each heartbeat tick:
 ### 2. Interactive (messages from the user)
 
 **Heartbeat control:**
-- "start" — set `agents.list[].heartbeat.every` to `"15m"` in `openclaw.json` via `config set`
+- "start" — set `agents.list[].heartbeat.every` to `"2h"` in `openclaw.json` via `config set` (2h is a safety-net fallback for missed webhooks; real-time triggering comes from GitHub webhooks)
+- "start fast" — set heartbeat to `"15m"` (use when webhooks are not configured)
 - "stop" — set `heartbeat.every` to `"0m"`
 
 **Triggering:**
 - "run `<repo>`" — run issue selection and spawn sessions immediately, regardless of schedule
-- "run `<repo>` #`<number>`" — spawn a session for that specific issue, skip selection
+- "run `<repo>` #`<number>`" — apply full selection filters (SQLite state, concurrency, labels) for that specific issue; spawn if eligible, skip if not
 - "run all" — trigger all enabled repos now
 
 **Managing repos:**
-- "add `<owner/repo>`" or "add `<owner/repo>` on `<branch>`" — add a project to config.json (inherits all defaults; branch defaults to `develop` if not specified)
-- "remove `<repo>`" — remove a project from config.json
+- "add `<owner/repo>`" or "add `<owner/repo>` on `<branch>`" — add a project to config.json (inherits all defaults; branch defaults to `develop` if not specified). If `WEBHOOK_URL` is set, also creates a GitHub webhook on the repo via `gh api repos/<owner>/<repo>/hooks` (requires admin permission — warn the user if missing, but still add to config).
+- "remove `<repo>`" — remove a project from config.json. If a GitHub webhook was previously created for this repo (detectable via `gh api repos/<owner>/<repo>/hooks`), delete it.
 - "pause `<repo>`" — set `enabled: false`
 - "resume `<repo>`" — set `enabled: true`
 
@@ -80,6 +101,7 @@ Uses SQLite (`forge.db`) for state tracking, combined with live GitHub and sessi
      - `queued` or `failed` (retryable) — eligible
      - `new` (not in db) — run `forge-db.sh queue <repo> <number> "<title>"`, then eligible
    - **Exclude labels** — skip issues with labels in `excludeLabels`
+   - **Include labels** — if `includeLabels` is defined (project or defaults), skip issues that have *no* label matching any entry in the list. `excludeLabels` takes priority: an issue matching both lists is skipped.
    - **Open PRs** — skip issues that already have an open PR (check branch names via `gh pr list`)
    - **Active sessions** — skip issues with an active ACP session (match `autopilot-<repo>-<number>` labels via `sessions_list`)
 
@@ -118,6 +140,7 @@ Every setting resolves: project-level > `defaults` block > built-in fallback.
 | `thread` | `true` |
 | `maxConcurrentSessions` | `4` |
 | `maxAttempts` | `3` |
+| `includeLabels` | `[]` (all issues eligible) |
 | `enabled` | `true` |
 
 ## SQLite tracking

--- a/agents/forge/SOUL.md
+++ b/agents/forge/SOUL.md
@@ -24,3 +24,11 @@ You are Forge, an autonomous development orchestrator. You monitor GitHub repos,
 - Projects: `/home/node/projects/`
 - Database: `/home/node/.openclaw/workspace/agents/forge/forge.db`
 - DB helper: `/home/node/.openclaw/workspace/agents/forge/forge-db.sh`
+
+## Environment Variables
+
+Webhook integration (optional — only needed when using GitHub webhook flow):
+
+- `WEBHOOK_URL` — Full URL of the OpenClaw hooks endpoint exposed via Tailscale Funnel (e.g., `https://sierranas.ts.net/hooks/github`)
+- `HOOKS_TOKEN` — Bearer token the HMAC proxy sends to authenticate with OpenClaw hooks
+- `GITHUB_WEBHOOK_SECRET` — Shared HMAC secret configured in GitHub webhook settings and the host-level proxy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,9 @@ services:
       - DISCORD_ALFRED_TOKEN=${DISCORD_ALFRED_TOKEN:-}
       - DISCORD_ALFRED_CHANNEL=${DISCORD_ALFRED_CHANNEL:-}
       - DISCORD_GUILD=${DISCORD_GUILD:-}
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - HOOKS_TOKEN=${HOOKS_TOKEN:-}
+      - GITHUB_WEBHOOK_SECRET=${GITHUB_WEBHOOK_SECRET:-}
       - GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/home/node/.config/gws/credentials.json
     volumes:
       - ./config/openclaw:/home/node/.openclaw

--- a/docs/webhooks-setup.md
+++ b/docs/webhooks-setup.md
@@ -1,0 +1,152 @@
+# GitHub Webhooks Setup
+
+Enables Forge to react to new GitHub issues in real-time instead of waiting for the heartbeat.
+
+## Architecture
+
+```
+GitHub → Tailscale Funnel (/hooks/) → HMAC proxy :18791 → OpenClaw :18789/hooks/github → Forge
+```
+
+The HMAC proxy (`scripts/gh-webhook-proxy.py`) runs as a systemd service on the **host** (not inside Docker). It:
+- Validates `X-Hub-Signature-256` HMAC from GitHub
+- Filters to `issues.opened` events only
+- Forwards to OpenClaw with Bearer token auth
+
+## Prerequisites
+
+- Tailscale with Funnel enabled on the NAS host
+- Python 3 on the host
+- A GitHub PAT with `admin:repo_hook` scope (for webhook lifecycle management)
+
+## Step 1: Generate secrets
+
+```bash
+# Bearer token for OpenClaw hooks auth (can reuse OPENCLAW_GATEWAY_TOKEN)
+openssl rand -hex 32   # → HOOKS_TOKEN
+
+# Shared secret for GitHub HMAC validation
+openssl rand -hex 32   # → GITHUB_WEBHOOK_SECRET
+```
+
+## Step 2: Configure .env
+
+Add to your `.env` file:
+
+```bash
+WEBHOOK_URL=https://<your-tailscale-hostname>/hooks/github
+HOOKS_TOKEN=<generated above>
+GITHUB_WEBHOOK_SECRET=<generated above>
+```
+
+## Step 3: Install the HMAC proxy on the host
+
+Copy the proxy script to the host:
+
+```bash
+sudo cp scripts/gh-webhook-proxy.py /usr/local/bin/gh-webhook-proxy.py
+sudo chmod +x /usr/local/bin/gh-webhook-proxy.py
+```
+
+Create a systemd service file at `/etc/systemd/system/gh-webhook-proxy.service`:
+
+```ini
+[Unit]
+Description=GitHub Webhook HMAC Proxy for OpenClaw
+After=network.target
+
+[Service]
+Type=simple
+User=<your-user>
+Environment=GITHUB_WEBHOOK_SECRET=<your-secret>
+Environment=HOOKS_TOKEN=<your-token>
+Environment=OPENCLAW_HOOKS_URL=http://127.0.0.1:18789/hooks/github
+Environment=PROXY_PORT=18791
+# Uncomment if Tailscale Funnel needs to reach the proxy from a different interface:
+# Environment=PROXY_HOST=0.0.0.0
+ExecStart=/usr/bin/python3 /usr/local/bin/gh-webhook-proxy.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable gh-webhook-proxy
+sudo systemctl start gh-webhook-proxy
+sudo systemctl status gh-webhook-proxy
+```
+
+## Step 4: Configure Tailscale Funnel
+
+Expose only port 18791 (where the HMAC proxy listens) publicly:
+
+```bash
+tailscale funnel --bg 18791
+```
+
+Verify your Funnel URL:
+
+```bash
+tailscale funnel status
+# Should show: https://<hostname>.ts.net -> http://127.0.0.1:18791
+```
+
+## Step 5: Rebuild and restart OpenClaw
+
+```bash
+make up
+```
+
+The `init.d/10-hooks.sh` script configures the hooks route automatically on startup (requires `HOOKS_TOKEN` to be set).
+
+## Step 6: Register webhook with GitHub repos
+
+In Forge (via Telegram/Discord):
+
+```
+add <owner/repo>
+```
+
+This adds the repo to Forge's config and (when `WEBHOOK_URL` is set) automatically creates the GitHub webhook.
+
+Or manually via `gh`:
+
+```bash
+gh api repos/<owner>/<repo>/hooks --method POST \
+  --field name=web \
+  --field active=true \
+  --field "events[]=issues" \
+  --field "config[url]=https://<hostname>.ts.net/hooks/github" \
+  --field "config[content_type]=json" \
+  --field "config[secret]=<GITHUB_WEBHOOK_SECRET>"
+```
+
+## Verification
+
+Check proxy logs:
+
+```bash
+sudo journalctl -u gh-webhook-proxy -f
+```
+
+Check OpenClaw logs:
+
+```bash
+make logs
+```
+
+A new issue on a tracked repo should trigger a Forge ACP session within seconds.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| 401 from proxy | Mismatched `GITHUB_WEBHOOK_SECRET` |
+| 502 from proxy | OpenClaw not running or wrong `OPENCLAW_HOOKS_URL` |
+| No Forge session spawned | Issue failed selection filters (check SQLite state, concurrency, labels) |
+| Funnel not reachable | `tailscale funnel status`, check firewall |

--- a/init.d/10-hooks.sh
+++ b/init.d/10-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 10-hooks.sh — Configure OpenClaw hooks for GitHub webhook integration
+# SCRIPT_NAME and log() are provided by docker-entrypoint.sh
+
+if [ -z "${HOOKS_TOKEN:-}" ]; then
+    log "HOOKS_TOKEN not set, skipping hooks configuration."
+    return 0
+fi
+
+# Check if route already configured
+EXISTING=$(node dist/index.js config get "hooks.routes" 2>/dev/null || echo "")
+if echo "$EXISTING" | grep -q "/hooks/github"; then
+    log "Hooks route /hooks/github already configured, skipping."
+    return 0
+fi
+
+log "Configuring GitHub webhook hooks route..."
+
+node dist/index.js config set "hooks.token" "\"${HOOKS_TOKEN}\"" --json
+
+node dist/index.js config set "hooks.routes" \
+    '[{"path":"/hooks/github","agentId":"forge","messageTemplate":"run {{repository.full_name}} #{{issue.number}}"}]' \
+    --json
+
+log "OK"

--- a/init.d/10-hooks.sh
+++ b/init.d/10-hooks.sh
@@ -7,9 +7,9 @@ if [ -z "${HOOKS_TOKEN:-}" ]; then
     return 0
 fi
 
-# Check if route already configured
+# Check if route already configured (jq parses JSON to avoid false matches on substrings)
 EXISTING=$(node dist/index.js config get "hooks.routes" 2>/dev/null || echo "")
-if echo "$EXISTING" | grep -q "/hooks/github"; then
+if echo "$EXISTING" | jq -e '.[] | select(.path == "/hooks/github")' >/dev/null 2>&1; then
     log "Hooks route /hooks/github already configured, skipping."
     return 0
 fi

--- a/scripts/gh-webhook-proxy.py
+++ b/scripts/gh-webhook-proxy.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""gh-webhook-proxy.py — entry point for the GitHub webhook HMAC validation proxy.
+
+See gh_webhook_proxy.py for the full implementation.
+"""
+from gh_webhook_proxy import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gh_webhook_proxy.py
+++ b/scripts/gh_webhook_proxy.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""gh-webhook-proxy.py — GitHub webhook HMAC validation proxy.
+
+Validates X-Hub-Signature-256, filters to issues.opened events,
+and forwards to OpenClaw gateway with Bearer token auth.
+
+Run as a systemd service on the host. See docs/webhooks-setup.md.
+
+Environment variables (required):
+  GITHUB_WEBHOOK_SECRET  Shared secret set in GitHub webhook config
+  HOOKS_TOKEN            Bearer token expected by OpenClaw hooks endpoint
+
+Environment variables (optional):
+  OPENCLAW_HOOKS_URL     Full URL of OpenClaw hooks endpoint
+                         Default: http://127.0.0.1:18789/hooks/github
+  PROXY_PORT             Port to listen on (default: 18791)
+  PROXY_HOST             Host to bind to (default: 127.0.0.1)
+"""
+import hashlib
+import hmac
+import http.server
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# --- Pure functions (testable without env vars) ---
+
+def verify_signature(body: bytes, signature_header: str, secret: bytes) -> bool:
+    """Return True if X-Hub-Signature-256 header matches body + secret."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    mac = hmac.new(secret, body, hashlib.sha256)
+    expected = "sha256=" + mac.hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def should_forward(event: str, action: str) -> bool:
+    """Return True only for issues.opened events."""
+    return event == "issues" and action == "opened"
+
+
+# --- Configuration (loaded from env at startup) ---
+
+GITHUB_WEBHOOK_SECRET: bytes = os.environ.get("GITHUB_WEBHOOK_SECRET", "").encode()
+HOOKS_TOKEN: str = os.environ.get("HOOKS_TOKEN", "")
+OPENCLAW_HOOKS_URL: str = os.environ.get(
+    "OPENCLAW_HOOKS_URL", "http://127.0.0.1:18789/hooks/github"
+)
+PROXY_PORT: int = int(os.environ.get("PROXY_PORT", "18791"))
+PROXY_HOST: str = os.environ.get("PROXY_HOST", "127.0.0.1")
+
+
+class WebhookHandler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+
+        # Validate HMAC signature
+        sig = self.headers.get("X-Hub-Signature-256", "")
+        if not verify_signature(body, sig, GITHUB_WEBHOOK_SECRET):
+            self._respond(401, b"Invalid signature")
+            return
+
+        # Parse payload
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self._respond(400, b"Invalid JSON")
+            return
+
+        # Filter: only issues.opened
+        event = self.headers.get("X-GitHub-Event", "")
+        action = payload.get("action", "")
+        if not should_forward(event, action):
+            self._respond(200, b"Ignored")
+            return
+
+        # Forward to OpenClaw
+        try:
+            req = urllib.request.Request(
+                OPENCLAW_HOOKS_URL,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {HOOKS_TOKEN}",
+                    "X-GitHub-Event": event,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                self._respond(resp.status, resp.read())
+        except urllib.error.URLError as e:
+            print(f"[proxy] Upstream error: {e}", file=sys.stderr)
+            self._respond(502, f"Upstream error: {e}".encode())
+
+    def _respond(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # noqa: N802
+        print(f"[proxy] {self.address_string()} {fmt % args}")
+
+
+def main() -> None:
+    if not GITHUB_WEBHOOK_SECRET:
+        print("ERROR: GITHUB_WEBHOOK_SECRET is not set", file=sys.stderr)
+        sys.exit(1)
+    if not HOOKS_TOKEN:
+        print("ERROR: HOOKS_TOKEN is not set", file=sys.stderr)
+        sys.exit(1)
+
+    server = http.server.HTTPServer((PROXY_HOST, PROXY_PORT), WebhookHandler)
+    print(f"[proxy] Listening on {PROXY_HOST}:{PROXY_PORT}")
+    print(f"[proxy] Forwarding issues.opened to {OPENCLAW_HOOKS_URL}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("[proxy] Shutting down.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gh_webhook_proxy.py
+++ b/scripts/gh_webhook_proxy.py
@@ -48,13 +48,13 @@ HOOKS_TOKEN: str = os.environ.get("HOOKS_TOKEN", "")
 OPENCLAW_HOOKS_URL: str = os.environ.get(
     "OPENCLAW_HOOKS_URL", "http://127.0.0.1:18789/hooks/github"
 )
-PROXY_PORT: int = int(os.environ.get("PROXY_PORT", "18791"))
+PROXY_PORT: str = os.environ.get("PROXY_PORT", "18791")
 PROXY_HOST: str = os.environ.get("PROXY_HOST", "127.0.0.1")
 
 
 class WebhookHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):  # noqa: N802
-        content_length = int(self.headers.get("Content-Length", 0))
+        content_length = int(self.headers.get("Content-Length") or 0)
         body = self.rfile.read(content_length)
 
         # Validate HMAC signature
@@ -113,8 +113,14 @@ def main() -> None:
         print("ERROR: HOOKS_TOKEN is not set", file=sys.stderr)
         sys.exit(1)
 
-    server = http.server.HTTPServer((PROXY_HOST, PROXY_PORT), WebhookHandler)
-    print(f"[proxy] Listening on {PROXY_HOST}:{PROXY_PORT}")
+    try:
+        port = int(PROXY_PORT)
+    except ValueError:
+        print(f"ERROR: PROXY_PORT must be an integer, got: {PROXY_PORT!r}", file=sys.stderr)
+        sys.exit(1)
+
+    server = http.server.HTTPServer((PROXY_HOST, port), WebhookHandler)
+    print(f"[proxy] Listening on {PROXY_HOST}:{port}")
     print(f"[proxy] Forwarding issues.opened to {OPENCLAW_HOOKS_URL}")
     try:
         server.serve_forever()

--- a/scripts/gh_webhook_proxy.py
+++ b/scripts/gh_webhook_proxy.py
@@ -36,7 +36,7 @@ def verify_signature(body: bytes, signature_header: str, secret: bytes) -> bool:
     return hmac.compare_digest(expected, signature_header)
 
 
-def should_forward(event: str, action: str) -> bool:
+def is_issues_opened(event: str, action: str) -> bool:
     """Return True only for issues.opened events."""
     return event == "issues" and action == "opened"
 
@@ -51,10 +51,15 @@ OPENCLAW_HOOKS_URL: str = os.environ.get(
 PROXY_PORT: str = os.environ.get("PROXY_PORT", "18791")
 PROXY_HOST: str = os.environ.get("PROXY_HOST", "127.0.0.1")
 
+MAX_BODY_BYTES: int = 1_048_576  # 1 MB — GitHub payloads are well under this
+
 
 class WebhookHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):  # noqa: N802
         content_length = int(self.headers.get("Content-Length") or 0)
+        if content_length > MAX_BODY_BYTES:
+            self._respond(413, b"Payload too large")
+            return
         body = self.rfile.read(content_length)
 
         # Validate HMAC signature
@@ -73,7 +78,7 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
         # Filter: only issues.opened
         event = self.headers.get("X-GitHub-Event", "")
         action = payload.get("action", "")
-        if not should_forward(event, action):
+        if not is_issues_opened(event, action):
             self._respond(200, b"Ignored")
             return
 
@@ -97,6 +102,7 @@ class WebhookHandler(http.server.BaseHTTPRequestHandler):
 
     def _respond(self, status: int, body: bytes) -> None:
         self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -119,7 +125,7 @@ def main() -> None:
         print(f"ERROR: PROXY_PORT must be an integer, got: {PROXY_PORT!r}", file=sys.stderr)
         sys.exit(1)
 
-    server = http.server.HTTPServer((PROXY_HOST, port), WebhookHandler)
+    server = http.server.ThreadingHTTPServer((PROXY_HOST, port), WebhookHandler)
     print(f"[proxy] Listening on {PROXY_HOST}:{port}")
     print(f"[proxy] Forwarding issues.opened to {OPENCLAW_HOOKS_URL}")
     try:

--- a/tests/test_gh_webhook_proxy.py
+++ b/tests/test_gh_webhook_proxy.py
@@ -1,0 +1,62 @@
+"""Tests for gh-webhook-proxy.py — HMAC signature validation."""
+import hashlib
+import hmac
+import sys
+import os
+import unittest
+
+# Add scripts/ to path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+# Set required env vars before importing (module reads them at import time)
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("HOOKS_TOKEN", "test-token")
+
+import gh_webhook_proxy as proxy
+
+
+def _make_sig(body: bytes, secret: str = "test-secret") -> str:
+    mac = hmac.new(secret.encode(), body, hashlib.sha256)
+    return "sha256=" + mac.hexdigest()
+
+
+class TestVerifySignature(unittest.TestCase):
+    def test_valid_signature(self):
+        body = b'{"action":"opened"}'
+        sig = _make_sig(body)
+        self.assertTrue(proxy.verify_signature(body, sig, b"test-secret"))
+
+    def test_invalid_hex(self):
+        body = b'{"action":"opened"}'
+        self.assertFalse(proxy.verify_signature(body, "sha256=deadbeef", b"test-secret"))
+
+    def test_missing_prefix(self):
+        body = b'{"action":"opened"}'
+        sig = _make_sig(body).replace("sha256=", "md5=")
+        self.assertFalse(proxy.verify_signature(body, sig, b"test-secret"))
+
+    def test_empty_header(self):
+        self.assertFalse(proxy.verify_signature(b"body", "", b"test-secret"))
+
+    def test_wrong_secret(self):
+        body = b'{"action":"opened"}'
+        sig = _make_sig(body, "wrong-secret")
+        self.assertFalse(proxy.verify_signature(body, sig, b"test-secret"))
+
+
+class TestShouldForward(unittest.TestCase):
+    def test_issues_opened(self):
+        self.assertTrue(proxy.should_forward("issues", "opened"))
+
+    def test_issues_closed(self):
+        self.assertFalse(proxy.should_forward("issues", "closed"))
+
+    def test_pull_request(self):
+        self.assertFalse(proxy.should_forward("pull_request", "opened"))
+
+    def test_push(self):
+        self.assertFalse(proxy.should_forward("push", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gh_webhook_proxy.py
+++ b/tests/test_gh_webhook_proxy.py
@@ -44,18 +44,18 @@ class TestVerifySignature(unittest.TestCase):
         self.assertFalse(proxy.verify_signature(body, sig, b"test-secret"))
 
 
-class TestShouldForward(unittest.TestCase):
+class TestIsIssuesOpened(unittest.TestCase):
     def test_issues_opened(self):
-        self.assertTrue(proxy.should_forward("issues", "opened"))
+        self.assertTrue(proxy.is_issues_opened("issues", "opened"))
 
     def test_issues_closed(self):
-        self.assertFalse(proxy.should_forward("issues", "closed"))
+        self.assertFalse(proxy.is_issues_opened("issues", "closed"))
 
     def test_pull_request(self):
-        self.assertFalse(proxy.should_forward("pull_request", "opened"))
+        self.assertFalse(proxy.is_issues_opened("pull_request", "opened"))
 
     def test_push(self):
-        self.assertFalse(proxy.should_forward("push", ""))
+        self.assertFalse(proxy.is_issues_opened("push", ""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds real-time webhook-driven issue discovery to Forge — GitHub `issues.opened` events trigger Forge immediately via a host-level HMAC proxy, replacing pure polling
- Introduces `includeLabels` filter for label-gated issue processing and updates `run repo #N` to apply full selection filters
- Heartbeat reduced to 2h fallback; webhook lifecycle (`add`/`remove`) auto-creates/deletes GitHub webhooks when `WEBHOOK_URL` is set

## Completed Tasks
- `docker-compose.yaml` — add `WEBHOOK_URL`, `HOOKS_TOKEN`, `GITHUB_WEBHOOK_SECRET` env vars
- `init.d/10-hooks.sh` — configure OpenClaw hooks route (`/hooks/github` → Forge) on container start
- `scripts/gh-webhook-proxy.py` — Python HMAC validation proxy (9 tests passing, ThreadingHTTPServer, 1MB body limit)
- `agents/forge/SOUL.md` — add webhook env var references
- `agents/forge/AGENTS.md` — document webhook flow, `includeLabels` filter, `run repo #N` behavior change, heartbeat 2h, `add`/`remove` webhook lifecycle
- `docs/webhooks-setup.md` — Tailscale Funnel + systemd proxy setup guide

## Failures
None.

---
Generated by `/build` from GitHub issue #12