### PR TITLE
fix: CLAUDE.md references init.d/00-tools.sh but file is 01-tools.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The OpenClaw base image version is pinned in `.openclaw-version` (CalVer `YYYY.M
 
 Volume mount: `./home` -> `/home/node` (single persistent volume for all runtime data)
 
-Claude CLI and GWS skills are installed at first boot by `init.d/00-tools.sh` and persist in the home volume.
+Claude CLI and GWS skills are installed at first boot by `init.d/01-tools.sh` and persist in the home volume.
 
 ## Git Conventions
 


### PR DESCRIPTION
## Summary
- Fix stale reference: `init.d/00-tools.sh` -> `init.d/01-tools.sh` in CLAUDE.md (renumbered in 4b16b05)

## Completed Tasks
- [x] Update script reference in CLAUDE.md

---
Closes #33

Generated by `/build` from GitHub issue #33