### PR TITLE
feat: add Ollama (local) as LLM provider option in make auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,10 @@ X_CLIENT_SECRET=
 # Set explicitly to use a fixed token across rebuilds.
 OPENCLAW_GATEWAY_TOKEN=
 
-# --- Optional ---
+# --- LLM Providers (set up interactively with: make auth) ---
 
 # OpenAI Codex token (for ChatGPT subscription model access)
-# Set up interactively with: make openai-codex
 OPENAI_CODEX_TOKEN=
+
+# Ollama host URL for local LLM inference (default: http://localhost:11434)
+OLLAMA_HOST=

--- a/Makefile
+++ b/Makefile
@@ -134,26 +134,25 @@ auth-ollama:       ## Set up Ollama (local LLM inference)
 	read -p "Ollama host URL [$$DEFAULT_HOST]: " INPUT_HOST; \
 	HOST=$${INPUT_HOST:-$$DEFAULT_HOST}; \
 	echo ""; \
+	case "$$HOST" in \
+	  http://*|https://*) ;; \
+	  *) echo "  Error: URL must start with http:// or https://"; exit 1;; \
+	esac; \
 	if [ ! -f .env ]; then \
 	  touch .env; chmod 600 .env; \
 	fi; \
-	ESCAPED_HOST=$$(printf '%s\n' "$$HOST" | sed 's/[[\.*^$$()+?{|&]/\\&/g'); \
-	if grep -qE '^OLLAMA_HOST=' .env 2>/dev/null; then \
-	  tmpfile=$$(mktemp); \
-	  sed "s|^OLLAMA_HOST=.*|OLLAMA_HOST=$$ESCAPED_HOST|" .env > "$$tmpfile"; \
-	  mv "$$tmpfile" .env; \
-	  chmod 600 .env; \
-	else \
-	  echo "OLLAMA_HOST=$$HOST" >> .env; \
-	  chmod 600 .env; \
-	fi; \
+	tmpfile=$$(mktemp); \
+	grep -v '^OLLAMA_HOST=' .env > "$$tmpfile" 2>/dev/null || true; \
+	echo "OLLAMA_HOST=$$HOST" >> "$$tmpfile"; \
+	mv "$$tmpfile" .env; \
+	chmod 600 .env; \
 	echo "  Saved OLLAMA_HOST=$$HOST to .env"; \
 	echo ""; \
 	echo "  Checking connectivity..."; \
 	if RESPONSE=$$(curl -sf --max-time 5 "$$HOST/api/tags" 2>/dev/null); then \
 	  echo "  Connected to Ollama at $$HOST"; \
 	  echo ""; \
-	  MODELS=$$(echo "$$RESPONSE" | grep -oE '"name"\s*:\s*"[^"]*"' | sed 's/"name"[[:space:]]*:[[:space:]]*"//;s/"$$//' | sed 's|^|  ollama/|'); \
+	  MODELS=$$(echo "$$RESPONSE" | jq -r '.models[].name // empty' 2>/dev/null | sed 's|^|  ollama/|'); \
 	  if [ -n "$$MODELS" ]; then \
 	    echo "  Available models:"; \
 	    echo "$$MODELS"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart restart-gateway logs logs-all status version config-preview config-reset shell dashboard auth auth-anthropic auth-codex test clean help
+.PHONY: up down restart restart-gateway logs logs-all status version config-preview config-reset shell dashboard auth auth-anthropic auth-codex auth-ollama test clean help
 
 OPENCLAW_VERSION := $(shell cat .openclaw-version 2>/dev/null || echo latest)
 export OPENCLAW_VERSION
@@ -72,44 +72,49 @@ dashboard:         ## Open dashboard: auto-approve pending devices, print URL
 	echo "http://localhost:18789/?token=$$TOKEN"
 
 auth:              ## Authenticate an LLM provider (interactive selector)
-	@if ! docker compose ps --status running 2>/dev/null | grep -q openclaw-gateway; then \
-	  echo "Error: Gateway is not running. Run 'make up' first."; exit 1; \
-	fi; \
-	echo ""; \
+	@echo ""; \
 	AUTH_FILE="home/.openclaw/workspace/agents/main/auth-profiles.json"; \
-	CODEX_TAG=""; ANTHROPIC_TAG=""; \
+	CODEX_TAG=""; ANTHROPIC_TAG=""; OLLAMA_TAG=""; \
 	if [ -f "$$AUTH_FILE" ]; then \
 	  if grep -q "openai-codex" "$$AUTH_FILE" 2>/dev/null; then CODEX_TAG=" [authenticated]"; fi; \
 	  if grep -q "anthropic" "$$AUTH_FILE" 2>/dev/null; then ANTHROPIC_TAG=" [authenticated]"; fi; \
 	fi; \
+	if [ -f .env ] && grep -qE '^OLLAMA_HOST=.+' .env 2>/dev/null; then OLLAMA_TAG=" [configured]"; fi; \
 	echo "  Agents need at least one LLM provider to work."; \
 	echo ""; \
 	CODEX_LABEL="OpenAI Codex (Recommended)$$CODEX_TAG"; \
 	ANTHROPIC_LABEL="Anthropic (Claude Code)$$ANTHROPIC_TAG"; \
+	OLLAMA_LABEL="Ollama (Local)$$OLLAMA_TAG"; \
 	if command -v gum >/dev/null 2>&1; then \
-	  PROVIDER=$$(printf '%s\n%s\n%s' "$$CODEX_LABEL" "$$ANTHROPIC_LABEL" "Exit" | gum choose --header "Select LLM provider:"); \
+	  PROVIDER=$$(printf '%s\n%s\n%s\n%s' "$$CODEX_LABEL" "$$ANTHROPIC_LABEL" "$$OLLAMA_LABEL" "Exit" | gum choose --header "Select LLM provider:"); \
 	else \
 	  echo "  Select LLM provider:"; \
 	  echo "    1) $$CODEX_LABEL"; \
 	  echo "    2) $$ANTHROPIC_LABEL"; \
-	  echo "    3) Exit"; \
+	  echo "    3) $$OLLAMA_LABEL"; \
+	  echo "    4) Exit"; \
 	  echo ""; \
-	  read -p "  Choice [1-3]: " choice; \
+	  read -p "  Choice [1-4]: " choice; \
 	  case "$$choice" in \
 	    1) PROVIDER="OpenAI Codex";; \
 	    2) PROVIDER="Anthropic";; \
-	    3) PROVIDER="Exit";; \
+	    3) PROVIDER="Ollama";; \
+	    4) PROVIDER="Exit";; \
 	    *) echo "Invalid selection."; exit 1;; \
 	  esac; \
 	fi; \
 	case "$$PROVIDER" in \
 	  OpenAI*) $(MAKE) auth-codex;; \
 	  Anthropic*) $(MAKE) auth-anthropic;; \
+	  Ollama*) $(MAKE) auth-ollama;; \
 	  Exit*) echo "  Skipped. Run 'make auth' when ready.";; \
 	  *) echo "No provider selected."; exit 1;; \
 	esac
 
 auth-anthropic:    ## Set up Anthropic OAuth (interactive paste-token)
+	@if ! docker compose ps --status running 2>/dev/null | grep -q openclaw-gateway; then \
+	  echo "Error: Gateway is not running. Run 'make up' first."; exit 1; \
+	fi
 	@echo ""
 	@echo "  WARNING: Using Anthropic OAuth subscription tokens outside of official"
 	@echo "  Claude tools may violate Anthropic's Terms of Service. Your account"
@@ -119,7 +124,50 @@ auth-anthropic:    ## Set up Anthropic OAuth (interactive paste-token)
 	docker compose exec openclaw-gateway node dist/index.js models auth paste-token --provider anthropic
 
 auth-codex:        ## Set up OpenAI Codex OAuth
+	@if ! docker compose ps --status running 2>/dev/null | grep -q openclaw-gateway; then \
+	  echo "Error: Gateway is not running. Run 'make up' first."; exit 1; \
+	fi
 	docker compose exec openclaw-gateway node dist/index.js models auth login --provider openai-codex
+
+auth-ollama:       ## Set up Ollama (local LLM inference)
+	@DEFAULT_HOST="http://localhost:11434"; \
+	read -p "Ollama host URL [$$DEFAULT_HOST]: " INPUT_HOST; \
+	HOST=$${INPUT_HOST:-$$DEFAULT_HOST}; \
+	echo ""; \
+	if [ ! -f .env ]; then \
+	  touch .env; chmod 600 .env; \
+	fi; \
+	ESCAPED_HOST=$$(printf '%s\n' "$$HOST" | sed 's|[[\.*^$$()+?{|&]|\\&|g'); \
+	if grep -qE '^OLLAMA_HOST=' .env 2>/dev/null; then \
+	  tmpfile=$$(mktemp); \
+	  sed "s|^OLLAMA_HOST=.*|OLLAMA_HOST=$$ESCAPED_HOST|" .env > "$$tmpfile"; \
+	  mv "$$tmpfile" .env; \
+	  chmod 600 .env; \
+	else \
+	  echo "OLLAMA_HOST=$$HOST" >> .env; \
+	  chmod 600 .env; \
+	fi; \
+	echo "  Saved OLLAMA_HOST=$$HOST to .env"; \
+	echo ""; \
+	echo "  Checking connectivity..."; \
+	if RESPONSE=$$(curl -sf --max-time 5 "$$HOST/api/tags" 2>/dev/null); then \
+	  echo "  Connected to Ollama at $$HOST"; \
+	  echo ""; \
+	  MODELS=$$(echo "$$RESPONSE" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$$//' | sed 's|^|  ollama/|'); \
+	  if [ -n "$$MODELS" ]; then \
+	    echo "  Available models:"; \
+	    echo "$$MODELS"; \
+	  else \
+	    echo "  No models found. Pull one with: ollama pull <model>"; \
+	  fi; \
+	else \
+	  echo "  Could not reach Ollama at $$HOST"; \
+	  echo "  Make sure Ollama is running: ollama serve"; \
+	fi; \
+	echo ""; \
+	if docker compose ps --status running 2>/dev/null | grep -q openclaw-gateway; then \
+	  echo "  Gateway is running. Restart to pick up changes: make restart-gateway"; \
+	fi
 
 # --- Maintenance ---
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ auth-ollama:       ## Set up Ollama (local LLM inference)
 	if [ ! -f .env ]; then \
 	  touch .env; chmod 600 .env; \
 	fi; \
-	ESCAPED_HOST=$$(printf '%s\n' "$$HOST" | sed 's|[[\.*^$$()+?{|&]|\\&|g'); \
+	ESCAPED_HOST=$$(printf '%s\n' "$$HOST" | sed 's/[[\.*^$$()+?{|&]/\\&/g'); \
 	if grep -qE '^OLLAMA_HOST=' .env 2>/dev/null; then \
 	  tmpfile=$$(mktemp); \
 	  sed "s|^OLLAMA_HOST=.*|OLLAMA_HOST=$$ESCAPED_HOST|" .env > "$$tmpfile"; \
@@ -153,7 +153,7 @@ auth-ollama:       ## Set up Ollama (local LLM inference)
 	if RESPONSE=$$(curl -sf --max-time 5 "$$HOST/api/tags" 2>/dev/null); then \
 	  echo "  Connected to Ollama at $$HOST"; \
 	  echo ""; \
-	  MODELS=$$(echo "$$RESPONSE" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$$//' | sed 's|^|  ollama/|'); \
+	  MODELS=$$(echo "$$RESPONSE" | grep -oE '"name"\s*:\s*"[^"]*"' | sed 's/"name"[[:space:]]*:[[:space:]]*"//;s/"$$//' | sed 's|^|  ollama/|'); \
 	  if [ -n "$$MODELS" ]; then \
 	    echo "  Available models:"; \
 	    echo "$$MODELS"; \


### PR DESCRIPTION
## Summary
Adds Ollama as a third LLM provider option in `make auth`, enabling users to use local LLM inference without requiring the gateway container to be running.

## Source
[SOL-24](https://linear.app/dasirra/issue/SOL-24/add-ollama-local-as-llm-provider-option-in-make-auth)

## What Changed
- **`.env.example`**: Added `OLLAMA_HOST=` variable with documentation comment in a renamed "LLM Providers" section
- **`Makefile`**:
  - Added `auth-ollama` to `.PHONY`
  - Moved gateway-running check from `auth` into `auth-codex` and `auth-anthropic` individually (Ollama doesn't need the container)
  - Added "Ollama (Local)" as third menu option with `[configured]` tag detection
  - New `auth-ollama` target: prompts for host URL (default `http://localhost:11434`), saves to `.env`, verifies connectivity via `curl /api/tags`, lists available models, suggests restart if gateway is running

## Tasks
| Task | Status | Notes |
|------|--------|-------|
| Add OLLAMA_HOST to .env.example | DONE | |
| Update Makefile with Ollama provider support | DONE | |
| Run tests to verify nothing is broken | DONE | All 85 bats tests pass |

## Code Review
- **MUST_FIX (resolved)**: Sed escape pattern used `|` as delimiter conflicting with `|` inside character class. Fixed by switching inner sed to `/` delimiter.
- **SHOULD_FIX (resolved)**: Model name grep didn't handle JSON whitespace (`"name": "value"`). Fixed with `\s*:\s*` pattern.

---
Built autonomously by `/build`